### PR TITLE
Reset client->send_offset on reinit

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -189,6 +189,7 @@ void mqtt_reinit(struct mqtt_client* client,
     client->socketfd = socketfd;
 
     mqtt_mq_init(&client->mq, sendbuf, sendbufsz);
+    client->send_offset = 0;
 
     client->recv_buffer.mem_start = recvbuf;
     client->recv_buffer.mem_size = recvbufsz;


### PR DESCRIPTION
This PR fixes a bug that can cause problems when calling mqtt_reinit(), for example from the reconnect callback.

If the connection is re-established while sending multi-part messages then MQTT-C will send garbage data from an old offset into the re-initialised message queue. Ultimately leading to junk being sent to the host.

This behaviour has been observed in the wild on devices with intermittent network connections.