### PR TITLE
Fix MQTT-C issue with TLS 1.3 session tickets

### DIFF
--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -53,6 +53,11 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     while(sent < len) {
         int rv = mbedtls_ssl_write(fd, (const unsigned char*)buf + sent, len - sent);
         if (rv < 0) {
+#if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+            if (rv == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+                continue;
+            }
+#endif
             if (rv == MBEDTLS_ERR_SSL_WANT_READ ||
                 rv == MBEDTLS_ERR_SSL_WANT_WRITE
 #if defined(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS)
@@ -99,6 +104,11 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
             break;
         }
         if (rv < 0) {
+#if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+            if (rv == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+                continue;
+            }
+#endif
             if (rv == MBEDTLS_ERR_SSL_WANT_READ ||
                 rv == MBEDTLS_ERR_SSL_WANT_WRITE
 #if defined(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS)


### PR DESCRIPTION
TLS 1.3 server may choose to issue new session ticket in the middle of active connection. This will cause next mbedtls_ssl_read() or mbedtls_ssl_write() to return MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET. This is not a real error, rather notification to the application to save session ticket for later use. As TLS reconnection is out of scope at this point we can safely ignore it and retry operation.

Please refer to mbedtls/programs/ssl/ssl_client2.c for session ticket handling.