### PR TITLE
increment the var. client->number_of_keep_alives

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -614,13 +614,13 @@ ssize_t __mqtt_send(struct mqtt_client *client)
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
             }
             break;
+        case MQTT_CONTROL_PINGREQ:
+            client->number_of_keep_alives += 1;
         case MQTT_CONTROL_CONNECT:
         case MQTT_CONTROL_PUBREC:
         case MQTT_CONTROL_PUBREL:
         case MQTT_CONTROL_SUBSCRIBE:
         case MQTT_CONTROL_UNSUBSCRIBE:
-        case MQTT_CONTROL_PINGREQ:
-            client->number_of_keep_alives += 1;
             msg->state = MQTT_QUEUED_AWAITING_ACK;
             break;
         default:

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -620,6 +620,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
         case MQTT_CONTROL_SUBSCRIBE:
         case MQTT_CONTROL_UNSUBSCRIBE:
         case MQTT_CONTROL_PINGREQ:
+            client->number_of_keep_alives += 1;
             msg->state = MQTT_QUEUED_AWAITING_ACK;
             break;
         default:


### PR DESCRIPTION
A quick inspection of the source code shows that the variable client->number_of_keep_alives is never incremented. This PR increments it on __mqtt_send() when a keep alive is sent.