### PR TITLE
Add library.json for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,20 @@
+{
+  "name": "MQTT-C",
+  "version": "main",
+  "description": "portable, embedded friendly MQTT client library",
+  "homepage": "https://liambindle.ca/MQTT-C/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/liambindle.ca/MQTT-C.git"
+  },
+  "license": "MIT",
+  "headers": [
+    "mqtt.h",
+    "mqtt_pal.h"
+  ],
+  "build": {
+    "flags": ["-DMQTT_USE_CUSTOM_SOCKET_HANDLE"],
+    "includeDir": "include",
+    "srcDir": "src"
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=MQTT-C
+version=0.1
+author=Liam Bindle,Demilade Adeoye
+maintainer=Liam Bindle
+sentence=Portable, embedded friendly MQTT client library.
+paragraph=Fully portable, network access must be provided by the user.
+category=Communication
+url=https://liambindle.ca/MQTT-C/
+includes=mqtt.h


### PR DESCRIPTION
[PlatformIO](https://platformio.org/) is an increasingly popular build system for embedded software. (I am not affiliated with it in any way.) It has a library manager that can establish dependencies directly to github repositories,
given only a [relatively simple `library.json` file with package metadata and build instructions](https://docs.platformio.org/en/latest/manifests/library-json/index.html). This is such a file.