### PR TITLE
Do a message queue gc after receiving messages.

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -890,6 +890,11 @@ ssize_t __mqtt_recv(struct mqtt_client *client)
           client->recv_buffer.curr -= consumed;
           client->recv_buffer.curr_sz += (unsigned long)consumed;
         }
+
+        /* Free up space by removing processed messages */
+        mqtt_mq_clean(&client->mq);
+        if(client->error == MQTT_ERROR_SEND_BUFFER_IS_FULL && client->mq.curr_sz > 0)
+            client->error = MQTT_OK;
     }
 
     /* In case there was some error handling the (well formed) message, we end up here */


### PR DESCRIPTION
Clean out messages that were waiting for ACK and clear the client error in case it was MQTT_ERROR_SEND_BUFFER_IS_FULL and the TX queue now has room again.
I did notice failing tests earlier but now I can't reproduce them. It's possible that they failed due to using the remote Mosquitto broker.

This is an alternative fix to #155.